### PR TITLE
Allow Stringable variables in if statements

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -42,7 +42,7 @@ final class Runtime
      *
      * @return bool Return true when the value is not null nor false.
      */
-    public static function ifvar(mixed $v, bool $zero): bool
+    public static function ifvar(mixed $v, bool $zero = false): bool
     {
         return $v !== null
             && $v !== false

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -10,19 +10,19 @@ class RuntimeTest extends TestCase
 {
     public function testIfVar(): void
     {
-        $this->assertFalse(Runtime::ifvar(null, false));
-        $this->assertFalse(Runtime::ifvar(0, false));
+        $this->assertFalse(Runtime::ifvar(null));
+        $this->assertFalse(Runtime::ifvar(0));
         $this->assertTrue(Runtime::ifvar(0, true));
-        $this->assertFalse(Runtime::ifvar(false, false));
-        $this->assertTrue(Runtime::ifvar(true, false));
-        $this->assertTrue(Runtime::ifvar(1, false));
-        $this->assertFalse(Runtime::ifvar('', false));
-        $this->assertTrue(Runtime::ifvar('0', false));
-        $this->assertFalse(Runtime::ifvar([], false));
-        $this->assertTrue(Runtime::ifvar([''], false));
-        $this->assertTrue(Runtime::ifvar([0], false));
-        $this->assertFalse(Runtime::ifvar(self::createStringable(''), false));
-        $this->assertTrue(Runtime::ifvar(self::createStringable('0'), false));
+        $this->assertFalse(Runtime::ifvar(false));
+        $this->assertTrue(Runtime::ifvar(true));
+        $this->assertTrue(Runtime::ifvar(1));
+        $this->assertFalse(Runtime::ifvar(''));
+        $this->assertTrue(Runtime::ifvar('0'));
+        $this->assertFalse(Runtime::ifvar([]));
+        $this->assertTrue(Runtime::ifvar(['']));
+        $this->assertTrue(Runtime::ifvar([0]));
+        $this->assertFalse(Runtime::ifvar(self::createStringable('')));
+        $this->assertTrue(Runtime::ifvar(self::createStringable('0')));
     }
 
     public function testIsec(): void


### PR DESCRIPTION
This PR enables users to evaluate variables that are of type `\Stringable` in an `if` statement:

```hbs
{{#if myVariable}}
  Shown when (string) $myVariable is a true-ish string.
{{/if}}
```